### PR TITLE
Added `refresh` method

### DIFF
--- a/codemirror.vue
+++ b/codemirror.vue
@@ -192,6 +192,9 @@
       }
     },
     methods: {
+      refresh: function() {
+        this.editor.refresh();
+      },
       unseenLineMarkers: function () {
         var _this = this
         if (_this.unseenLines !== undefined && _this.marker !== undefined) {

--- a/codemirror.vue
+++ b/codemirror.vue
@@ -193,7 +193,7 @@
     },
     methods: {
       refresh: function() {
-        this.editor.refresh();
+        this.editor.refresh()
       },
       unseenLineMarkers: function () {
         var _this = this


### PR DESCRIPTION
It helped me with the problem when I use codemirror component in a modal window. 
I had a problem when I opened my modal and passed an empty value to the component - it showed me previous value until I clicked on the editor.
I call this new method after my modal opened and it refreshes!
Please, approve my PR, it won't break anything but is very useful :D