### PR TITLE
Enable switching from/to DiffView based on 'merge' prop status

### DIFF
--- a/src/codemirror.vue
+++ b/src/codemirror.vue
@@ -84,6 +84,9 @@
           }
         }
       },
+      merge(newVal) {
+        this.$nextTick(this.switchMerge);
+      },
       code(newVal, oldVal) {
         this.handerCodeChange(newVal, oldVal)
       },
@@ -179,6 +182,19 @@
             this.cminstance.setGutterMarker(line, 'breakpoints', info.gutterMarkers ? null : this.marker())
           })
         }
+      },
+      switchMerge() {
+        // Save current values
+        let history = this.cminstance.doc.history;
+        let cleanGeneration = this.cminstance.doc.cleanGeneration;
+        this.options.value = this.cminstance.getValue();
+
+        this.destroy();
+        this.initialize();
+
+        // Restore values
+        this.cminstance.doc.history = history;
+        this.cminstance.doc.cleanGeneration = cleanGeneration;
       }
     },
     mounted() {


### PR DESCRIPTION
Switch from Classic mode to DiffView (back and forth) based on 'merge' prop status. History, value and cleanGeneration are preserved.
User has to provide orig(Right) or origLeft and set 'merge' to true (has you would do in a statically initialized DiffView instance)

So far, 'merge' prop is only used at initialization and there is no watcher.

Idea came from the need in one of our project to examine patches while editing (thus switching from classic editor to merge view)