### PR TITLE
a few cleanups and improvements

### DIFF
--- a/src/codemirror.vue
+++ b/src/codemirror.vue
@@ -78,20 +78,20 @@
     watch: {
       options: {
         deep: true,
-        handler(options, oldOptions) {
+        handler(options) {
           for (const key in options) {
             this.cminstance.setOption(key, options[key])
           }
         }
       },
-      merge(newVal) {
+      merge() {
         this.$nextTick(this.switchMerge)
       },
-      code(newVal, oldVal) {
-        this.handerCodeChange(newVal, oldVal)
+      code(newVal) {
+        this.handleCodeChange(newVal)
       },
-      value(newVal, oldVal) {
-        this.handerCodeChange(newVal, oldVal)
+      value(newVal) {
+        this.handleCodeChange(newVal)
       }
     },
     methods: {
@@ -165,7 +165,7 @@
         const element = this.cminstance.doc.cm.getWrapperElement()
         element && element.remove && element.remove()
       },
-      handerCodeChange(newVal, oldVal) {
+      handleCodeChange(newVal) {
         const cm_value = this.cminstance.getValue()
         if (newVal !== cm_value) {
           const scrollInfo = this.cminstance.getScrollInfo()


### PR DESCRIPTION
Some of these functions had a second parameter defined for no reason (they don't use that parameter), so those shouldn't be there. Also, it looks like "handerCodeChange" is just misspelled—the intended word is "handle". These changes make the code slightly easier to understand and more lightweight. :)