### PR TITLE
Provide option avoid using global codemirror instance

### DIFF
--- a/config/base.conf.js
+++ b/config/base.conf.js
@@ -5,8 +5,8 @@ const webpack = require('webpack')
 const resolve = dir => path.join(__dirname, '..', dir)
 
 const env = process.env.NODE_ENV === 'testing'
-  ? { NODE_ENV: '"testing"' }
-  : { NODE_ENV: '"production"' }
+  ? { NODE_ENV: '"testing"', EXCLUDE_GLOBAL_CODEMIRROR: process.env.EXCLUDE_GLOBAL_CODEMIRROR }
+  : { NODE_ENV: '"production"', EXCLUDE_GLOBAL_CODEMIRROR: process.env.EXCLUDE_GLOBAL_CODEMIRROR }
 
 module.exports = {
   module: {

--- a/src/codemirror.js
+++ b/src/codemirror.js
@@ -1,0 +1,11 @@
+import _CodeMirror from 'codemirror'
+
+const globalCodeMirror = () => {
+  return process.env.EXCLUDE_GLOBAL_CODEMIRROR ? undefined : window.CodeMirror
+}
+
+const CodeMirror = globalCodeMirror() || _CodeMirror
+
+export default CodeMirror
+
+

--- a/src/codemirror.vue
+++ b/src/codemirror.vue
@@ -7,8 +7,7 @@
 
 <script>
   // lib
-  import _CodeMirror from 'codemirror'
-  const CodeMirror = window.CodeMirror || _CodeMirror
+  import CodeMirror from './codemirror'
 
   // pollfill
   if (typeof Object.assign != 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,9 @@
 * Github: https://github.com/surmon-china/vue-codemirror
 */
 
-import _CodeMirror from 'codemirror'
+import CodeMirror from './codemirror'
 import codemirror from './codemirror.vue'
 
-const CodeMirror = window.CodeMirror || _CodeMirror
 const install = (Vue, config) => {
   if (config) {
     if (config.options) {


### PR DESCRIPTION
Added an option EXCLUDE_GLOBAL_CODEMIRROR to the build which avoid loading CodeMirror from global scope (window) if available.
By default, behave the same than currently, to activate:
EXCLUDE_GLOBAL_CODEMIRROR=true

In an environment with different plugins bringing their own set of dependencies in the browser, sometimes, a plugin wants to isolate itself from others. Why, because other plugins could import and expose globally their own version of CodeMirror which could be outdated or incompatible with the plugin usage, or even configured in a different way.

That way, we're sure the use and to configure the CodeMirror instance embedded with the plugin and not shared with others.