### PR TITLE
Change codemirror as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "publish": "git push && git push --tags && npm publish"
   },
   "dependencies": {
-    "codemirror": "^5.41.0",
     "diff-match-patch": "^1.0.0"
   },
   "expDependencies": {
@@ -70,6 +69,7 @@
     "babel-register": "^6.0.0",
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
+    "codemirror": "^5.65.0",
     "connect-history-api-fallback": "^1.1.0",
     "copy-webpack-plugin": "^4.0.0",
     "cross-env": "^5.0.0",
@@ -126,6 +126,9 @@
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.16.1",
     "webpack-merge": "^2.6.1"
+  },
+  "peerDependencies": {
+    "codemirror": "^5.65.0"
   },
   "engines": {
     "node": ">= 4.0.0",


### PR DESCRIPTION
In the case of using `pnpm`, if you need to import `codemirror` related files, you need to install both `vue-codemirror` and `codemirror` in the project, which will cause `Cannot read property'attach' of undefined` even if it has been added :
```js
import'codemirror/keymap/sublime';
```

使用 `pnpm` 的情况下，如果需要引入 `codemirror` 相关文件，需要在项目中同时安装 `vue-codemirror` 和 `codemirror` ，这会导致 `Cannot read property 'attach' of undefined` 即使已经添加了：
```js
import 'codemirror/keymap/sublime';
```