### PR TITLE
Added type: module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dist",
     "CHANGELOG.md"
   ],
+  "type": "module",
   "main": "./dist/vue-codemirror.cjs.js",
   "module": "./dist/vue-codemirror.esm.js",
   "types": "./dist/vue-codemirror.esm.d.ts",


### PR DESCRIPTION
Hello,

as the title says, I only added `"type": "module"` to `package.json`. The `type` key apparently tells Vite to treat the package as an ES module and avoid error messages like `Cannot use import statement outside a module` when using SSR. I know that not every Vite setup seems to lead to these error messages, but this is how [headlessui](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-vue/package.json#L18) and a few other packages I came across do it. 

I'd appreciate it if you would consider adding this change. Thanks!