### PR TITLE
Fix build with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vue-codemirror",
   "description": "CodeMirror code editor component for Vue",
+  "type": "module",
   "version": "6.1.1",
   "author": "Surmon",
   "license": "MIT",


### PR DESCRIPTION
When you try to build your project with `vite` (Experienced in latest `vitepress`) you'll get into rollup during builds issues as the library supports ESM, but its package.json is not defined as such. This property makes build tools properly identify it as an ESM library.